### PR TITLE
230 fix link in wardrobe inventory project

### DIFF
--- a/TCSA.V2/Helpers/ProjectsSubHelpers/BlazorProjectsHelper.cs
+++ b/TCSA.V2/Helpers/ProjectsSubHelpers/BlazorProjectsHelper.cs
@@ -43,7 +43,7 @@ internal static class BlazorProjectsHelper
                 },
                 Resources = new List<string>
                 {
-                    "<a target='_blank' href='https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?view=aspnetcore-6.0&tabs=visual-studio'>Microsoft Docs: Blazor</a>",
+                    "<a target='_blank' href='https://learn.microsoft.com/en-us/aspnet/core/blazor/'>Microsoft Docs: Blazor</a>",
                     "<a target='_blank' href='https://www.c-sharpcorner.com/article/blazor-what-it-is-why-should-we-use-it/'>Why use Blazor?</a>",
                     "<a target='_blank' href='https://www.c-sharpcorner.com/blogs/create-a-net-6-app-on-blazor-wasm-for-crud-operations-with-ef-core'>Blazor CRUD Tutorial</a>"
                 },

--- a/TCSA.V2/Helpers/ProjectsSubHelpers/BlazorProjectsHelper.cs
+++ b/TCSA.V2/Helpers/ProjectsSubHelpers/BlazorProjectsHelper.cs
@@ -44,6 +44,7 @@ internal static class BlazorProjectsHelper
                 Resources = new List<string>
                 {
                     "<a target='_blank' href='https://learn.microsoft.com/en-us/aspnet/core/blazor/'>Microsoft Docs: Blazor</a>",
+                    "<a target='_blank' href='https://learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/build-a-blazor-app'>Microsoft Docs: Build a Blazor todo list app</a>",
                     "<a target='_blank' href='https://www.c-sharpcorner.com/article/blazor-what-it-is-why-should-we-use-it/'>Why use Blazor?</a>",
                     "<a target='_blank' href='https://www.c-sharpcorner.com/blogs/create-a-net-6-app-on-blazor-wasm-for-crud-operations-with-ef-core'>Blazor CRUD Tutorial</a>"
                 },


### PR DESCRIPTION
This PR will:
 - Update the link to the Blazor docs that was pointing to the wrong location 
 - Add the missing link. The link to Blazor ToDo tutorial was mentioned in the text but it was missing from the Resources section