### PR TITLE
Fixed peer review visibility

### DIFF
--- a/TCSA.V2/Services/PeerReviewService.cs
+++ b/TCSA.V2/Services/PeerReviewService.cs
@@ -98,11 +98,11 @@ public class PeerReviewService : IPeerReviewService
             {
                 var level = context.Users.FirstOrDefault(x => x.Id == reviewerId).Level;
 
-                if (level <= Level.Yellow) 
+                if (level < Level.Yellow) 
                 { 
                     return new List<DashboardProject> { }; 
                 }
-                else 
+                else if( level > Level.Yellow)
                 {
                     beginnerProjects.AddRange(new List<int> { 14, 15, 16, 17 });
                 }
@@ -150,7 +150,7 @@ public class PeerReviewService : IPeerReviewService
                 {
                     return 0;
                 }
-                else
+                else if (level > Level.Yellow)
                 {
                     beginnerProjects.AddRange(new List<int> { 14, 15, 16, 17 });
                 }

--- a/TCSA.V2/Services/PeerReviewService.cs
+++ b/TCSA.V2/Services/PeerReviewService.cs
@@ -98,7 +98,7 @@ public class PeerReviewService : IPeerReviewService
             {
                 var level = context.Users.FirstOrDefault(x => x.Id == reviewerId).Level;
 
-                if (level < Level.Yellow) 
+                if (level <= Level.Yellow) 
                 { 
                     return new List<DashboardProject> { }; 
                 }


### PR DESCRIPTION
@TheCSharpAcademy  I've located the issue and have tested the results. Currently they are displayed as follows:

Yellow belt: Only beginner projects (53, 11, 12, 13)

Orange and Red belt: Intermediate projects (14, 15, 16, 17)

Purple belt and beyond: (18, 19, 20, 21)

I don't know if there's plans in the future for reviewing other code areas so I didn't mess with the code. But maybe we can refactor this with a helper. I'm not a fan of hard coding the project's id.