### PR TITLE
Add link to Peer Review Cards on Dashboard

### DIFF
--- a/TCSA.V2/Components/Dashboard/DashboardReviewCard.razor
+++ b/TCSA.V2/Components/Dashboard/DashboardReviewCard.razor
@@ -4,7 +4,9 @@
         <img src="img/cards/@IconUrl" width="60" alt="...">
     </div>
     <div class="col-md-4 col-6">
-        <p class="card-title-dashboard-review">@Title</p>
+        <a href=@Href target="_blank">
+            <p class="card-title-dashboard-review">@Title</p>
+        </a>
         <p class="project-card-text">@Name</p>
         <p class="project-card-submitted-duration">@DurationOpen</p>
         <div class="experience-points-reviews d-flex align-items-center">
@@ -61,9 +63,17 @@
     [Parameter] public string GithubUrl { get; set; }
     [Parameter] public string Status { get; set; }
     [Parameter] public int ExperiencePoints { get; set; }
+    [Parameter] public int ProjectId { get; set; }
+    [Parameter] public string ProjectSlug { get; set; }
     [Parameter] public EventCallback OnAssignCallBack { get; set; }
     [Parameter] public EventCallback OnMarkAsCompleteCallBack { get; set; }
     [Parameter] public MarkupString DurationOpen { get; set; }
+    public string Href { get; set; }
+    
+    protected async override Task OnParametersSetAsync()
+    {
+        Href = $"project/{ProjectId}/{ProjectSlug}";
+    }
 }
 
 <style>

--- a/TCSA.V2/Components/Dashboard/Pages/PeerReviews.razor
+++ b/TCSA.V2/Components/Dashboard/Pages/PeerReviews.razor
@@ -42,6 +42,8 @@
                                          Title=@GetProject(project.ProjectId).Title
                                          Name=@GetName(project.AppUserId)
                                          IconUrl=@GetProject(project.ProjectId).IconUrl
+                                         ProjectId=@GetProject(project.ProjectId).Id
+                                         ProjectSlug=@GetProject(project.ProjectId).Slug
                                          ExperiencePoints=@GetProject(project.ProjectId).ExperiencePoints
                                          GithubUrl=@project.GithubUrl
                                          OnAssignCallBack="@(() => AssignMyself(project.Id))"


### PR DESCRIPTION
makes the title of the project card a link to the project itself - easier access to the project page to review the requirements