### PR TITLE
Fix spacing

### DIFF
--- a/TCSA.V2/Components/Dashboard/DashboardHeader.razor
+++ b/TCSA.V2/Components/Dashboard/DashboardHeader.razor
@@ -41,11 +41,12 @@
 
 <style>
     .dashboard-header {
-        padding: 20px 0 !important;
+        padding: 20px 0 10px 0;
     }
 
     .user-level-text {
         margin-left: 10px;
+        margin-bottom: 0;
     }
 
     .belt-label {
@@ -54,16 +55,11 @@
 
     .belt-label-wrap {
         white-space: nowrap;
-        margin-bottom: -20px;
         padding-left: 10px;
     }
 
     .experience-points {
         font-weight: 900;
-    }
-
-    .dashboard-header {
-        padding: 20px 0 !important;
     }
 
     .img-belt-header {
@@ -77,7 +73,6 @@
     }
 
     .flag {
-        margin-bottom: 10px;
         border: 1px solid lightgrey;
     }
 


### PR DESCRIPTION
Fixes spacing between flag and belt #362 

Tried not to waste too much vertical space.

Before (in prod):
<img width="506" alt="belt-prod" src="https://github.com/TheCSharpAcademy/TCSA.V2/assets/5217930/cb984c64-e194-4da5-a8b7-3099d1c03b0c">


This PR's spacing fix:
<img width="526" alt="belt-fixed" src="https://github.com/TheCSharpAcademy/TCSA.V2/assets/5217930/0bebab3b-0547-43e6-a34a-5518ee3a8391">
