### PR TITLE
Reload article component when parameters change

### DIFF
--- a/TCSA.V2/Components/Pages/ArticlePage.razor
+++ b/TCSA.V2/Components/Pages/ArticlePage.razor
@@ -135,6 +135,11 @@
 
     protected async override Task OnInitializedAsync()
     {
+        await OnParametersSetAsync();
+    }
+
+    protected async override Task OnParametersSetAsync()
+    {
         Article = ArticleHelper.GetArticles().Single(x => x.Id == ArticleId);
         BackgroundImage = Article.BannerUrl != "" ? Article.BannerUrl : "article-banner.jpg";
 

--- a/TCSA.V2/Components/UI/NextButton.razor
+++ b/TCSA.V2/Components/UI/NextButton.razor
@@ -1,7 +1,5 @@
 ﻿
-<a href="@Href">
-    <button class="btn next-btn" type="button">Next</button>
-</a>
+<a href="@Href" class="btn next-btn">Next</a>
 
 @code {
     [Parameter]


### PR DESCRIPTION
by moving the setting of the properties to the OnParametersSetAsync() method it causes the component to reset them every time the url parameters have changed.
When this was not present the items were not refreshed as OnInitializeAsync is only called once when Article component is initialized.