### PR TITLE
402 code reviewer leaderboard

### DIFF
--- a/TCSA.V2/Components/Dashboard/Pages/Leaderboard.razor
+++ b/TCSA.V2/Components/Dashboard/Pages/Leaderboard.razor
@@ -17,6 +17,7 @@
     {
         <nav aria-label="Page navigation example">
             <btn class="btn btn-primary w-100 mb-3" @onclick="Filter2024">Click to See @(is2024 ? "all time" : "2024") Leaderboard</btn>
+            <btn class="btn btn-primary w-100 mb-3" @onclick="FilterReviews">Reviewers Leaderboard</btn>
 
             @if (!is2024 && Ranking > 50)
             {
@@ -155,6 +156,11 @@
         users = incomingUsers.ToList();
 
         isLoading = false;
+    }
+
+    protected async Task FilterReviews()
+    {
+        
     }
 
     protected async Task Filter2024()

--- a/TCSA.V2/Components/Dashboard/Pages/Leaderboard.razor
+++ b/TCSA.V2/Components/Dashboard/Pages/Leaderboard.razor
@@ -17,7 +17,7 @@
     {
         <nav aria-label="Page navigation example">
             <btn class="btn btn-primary w-100 mb-3" @onclick="Filter2024">Click to See @(is2024 ? "all time" : "2024") Leaderboard</btn>
-            <btn class="btn btn-primary w-100 mb-3" @onclick="FilterReviews">Reviewers Leaderboard</btn>
+            <btn class="btn btn-primary w-100 mb-3" @onclick="FilterReviews">Click to See @(isReviews ? "all time" : "reviews") Leaderboard</btn>
 
             @if (!is2024 && Ranking > 50)
             {
@@ -42,62 +42,103 @@
             <p>*The 2024 leaderboard only takes in consideration projects submitted in 2024</p>
         }
 
-        <table class="table leaderboard-table mt-sm-5">
-            <thead>
-                <tr>
-                    <th scope="col">Pos</th>
-                    <th scope="col">XP</th>
-                    <th scope="col">Name</th>
-                    <th scope="col" class="country-header">Country</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var user in users)
-                {
-                    <tr class="my-row @(user.Id == userId ? "is-user" : "")">
-                        <th class="leaderboard-cell index-cell" scope="row">@user.Ranking</th>
-                        <td class="leaderboard-cell">
-                            <div class="belt-label-wrap d-flex align-items-center">
-                                <div class="belt-label">
-                                    <img class="img-xp-leaderboard" src="img/experience.png" width="30" alt="...">
-                                </div>
-                                <div class="belt-label">
-                                    <p class="leaderboard-xp">@user.ExperiencePoints</p>
-                                </div>
-                            </div>
-                        </td>
-                        <td class="leaderboard-cell">
-                            <div class="name-cell">
-                                <div class="name-cell-name">@(user.DisplayName ??= $"{user.FirstName} {user.LastName}")</div>
-                                <div class="name-cell-level">
-                                    <div class="belt-name-wrap">
-                                        <div class="belt-label">
-                                            <img class="dashboard-belt" src="img/belts/@($"{user.Level}-belt.png")" width="20" alt="...">
-                                        </div>
-                                        <div class="belt-label">
-                                            @user.Level Belt
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                        <td class="leaderboard-cell country-cell">
-                            @if (!string.IsNullOrEmpty(user.Country))
-                            {
-                                <div class="row belt-label-wrap d-flex align-items-center">
-                                    <div class="col-3 belt-label d-flex align-items-center">
-                                        <img class="dashboard-flag" src="@FlagHelper.GetFlag(user.Country)" width="30" alt="...">
-                                    </div>
-                                    <div class="col-9 belt-label d-sm-none d-md-inline d-flex align-items-center">
-                                        <p class="leaderboard-country">@user.Country</p>
-                                    </div>
-                                </div>
-                            }
-                        </td>
+        if (!isReviews)
+        {
+            <table class="table leaderboard-table mt-sm-5">
+                <thead>
+                    <tr>
+                        <th scope="col">Pos</th>
+                        <th scope="col">XP</th>
+                        <th scope="col">Name</th>
+                        <th scope="col" class="country-header">Country</th>
                     </tr>
-                }
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    @foreach (var user in users)
+                    {
+                        <tr class="my-row @(user.Id == userId ? "is-user" : "")">
+                            <th class="leaderboard-cell index-cell" scope="row">@user.Ranking</th>
+                            <td class="leaderboard-cell">
+                                <div class="belt-label-wrap d-flex align-items-center">
+                                    <div class="belt-label">
+                                        <img class="img-xp-leaderboard" src="img/experience.png" width="30" alt="...">
+                                    </div>
+                                    <div class="belt-label">
+                                        <p class="leaderboard-xp">@user.ExperiencePoints</p>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="leaderboard-cell">
+                                <div class="name-cell">
+                                    <div class="name-cell-name">@(user.DisplayName ??= $"{user.FirstName} {user.LastName}")</div>
+                                    <div class="name-cell-level">
+                                        <div class="belt-name-wrap">
+                                            <div class="belt-label">
+                                                <img class="dashboard-belt" src="img/belts/@($"{user.Level}-belt.png")" width="20" alt="...">
+                                            </div>
+                                            <div class="belt-label">
+                                                @user.Level Belt
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="leaderboard-cell country-cell">
+                                @if (!string.IsNullOrEmpty(user.Country))
+                                {
+                                    <div class="row belt-label-wrap d-flex align-items-center">
+                                        <div class="col-3 belt-label d-flex align-items-center">
+                                            <img class="dashboard-flag" src="@FlagHelper.GetFlag(user.Country)" width="30" alt="...">
+                                        </div>
+                                        <div class="col-9 belt-label d-sm-none d-md-inline d-flex align-items-center">
+                                            <p class="leaderboard-country">@user.Country</p>
+                                        </div>
+                                    </div>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+
+        } else if (reviewUsers != null && isReviews)
+        {
+            <table class="table leaderboard-table mt-sm-5">
+                <thead>
+                    <tr>
+                        <th scope="col">Pos</th>
+                        <th scope="col">Name</th>
+                        <th scope="col">Total XP</th>
+                        <th scope="col">Total Reviews</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var user in reviewUsers)
+                    {
+                        <tr class="my-row @(user.Id == userId ? "is-user" : "")">
+                            <th class="leaderboard-cell index-cell" scope="row">@user.Ranking</th>
+                            <td class="leaderboard-cell">
+                                <div class="name-cell">
+                                    <div class="name-cell-name">@(user.DisplayName ??= $"{user.FirstName} {user.LastName}")</div>
+                                </div>
+                            </td>
+                            <td class="leaderboard-cell">
+                                <div class="belt-label-wrap d-flex align-items-center">
+                                    <div class="belt-label">
+                                        <p class="leaderboard-xp">@user.TotalXp</p>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="leaderboard-cell">
+                                <div class="name-cell">
+                                    <div class="name-cell-name">@user.ReviewsNumber</div>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
     }
     else
     {
@@ -113,11 +154,13 @@
     [Inject] private ILeaderboardService LeaderboardService { get; set; }
 
     private List<AppUserForLeaderboard>? users { get; set; } = null;
+    private List<AppUserForReviewLeaderboard>? reviewUsers { get; set; } = null;
 
     private int CurrentPage;
     private int Ranking;
     private bool isLoading = true;
     private bool is2024 = false;
+    private bool isReviews = false;
 
     private string userId = "";
 
@@ -143,6 +186,7 @@
 
             CurrentPage = Ranking / 50;
             await LoadPagination(CurrentPage);
+            await FilterReviews();
         }
     }
 
@@ -160,8 +204,19 @@
 
     protected async Task FilterReviews()
     {
-        var incomingUsers = await LeaderboardService.GetUsersForLeaderboard();
-        users = incomingUsers.ToList();
+        if (!isReviews)
+        {
+            isReviews = true;
+
+            var incomingUsers = await LeaderboardService.GetUserForReviewLeaderboard();
+            reviewUsers = incomingUsers.ToList();
+        } 
+        else
+        {
+            isReviews = false;
+            await LoadPagination(CurrentPage);
+        }
+
     }
 
     protected async Task Filter2024()
@@ -169,6 +224,7 @@
         if (!is2024)
         {
             is2024 = true;
+            isReviews = false;
             isLoading = true;
 
             var incomingUsers = await LeaderboardService.GetUsersForLeaderboard();
@@ -180,6 +236,7 @@
         else
         {
             is2024 = false;
+            isReviews = false;
             await LoadPagination(CurrentPage);
         }
     }

--- a/TCSA.V2/Components/Dashboard/Pages/Leaderboard.razor
+++ b/TCSA.V2/Components/Dashboard/Pages/Leaderboard.razor
@@ -160,7 +160,8 @@
 
     protected async Task FilterReviews()
     {
-        
+        var incomingUsers = await LeaderboardService.GetUsersForLeaderboard();
+        users = incomingUsers.ToList();
     }
 
     protected async Task Filter2024()

--- a/TCSA.V2/Data/ApplicationUser.cs
+++ b/TCSA.V2/Data/ApplicationUser.cs
@@ -24,7 +24,7 @@ public class ApplicationUser : IdentityUser
     public string? LinkedInUrl { get; set; }
     public string? GithubUsername { get; set; }
     public string? DisplayName { get; set; }
-    public int ReviewdProjects {  get; set; }
+    public int ReviewedProjects {  get; set; }
     public virtual ICollection<UserChallenge> UserChallenges { get; set; }
     public virtual ICollection<ShowcaseItem> ShowcaseItems { get; set; }
     public virtual DailyStreak DailyStreak { get; set; }

--- a/TCSA.V2/Data/ApplicationUser.cs
+++ b/TCSA.V2/Data/ApplicationUser.cs
@@ -13,6 +13,7 @@ public class ApplicationUser : IdentityUser
     public List<CommunityIssue>? Issues { get; set; }
     public Level Level { get; set; }
     public int ExperiencePoints { get; set; }
+    public int? ReviewExperiencePoints { get; set; }
     public DateTimeOffset CreatedDate { get; set; }
     public string Country { get; set; }
     public bool HasPendingBeltNotification { get; set; }

--- a/TCSA.V2/Data/ApplicationUser.cs
+++ b/TCSA.V2/Data/ApplicationUser.cs
@@ -13,7 +13,7 @@ public class ApplicationUser : IdentityUser
     public List<CommunityIssue>? Issues { get; set; }
     public Level Level { get; set; }
     public int ExperiencePoints { get; set; }
-    public int? ReviewExperiencePoints { get; set; }
+    public int ReviewExperiencePoints { get; set; }
     public DateTimeOffset CreatedDate { get; set; }
     public string Country { get; set; }
     public bool HasPendingBeltNotification { get; set; }
@@ -24,6 +24,7 @@ public class ApplicationUser : IdentityUser
     public string? LinkedInUrl { get; set; }
     public string? GithubUsername { get; set; }
     public string? DisplayName { get; set; }
+    public int ReviewdProjects {  get; set; }
     public virtual ICollection<UserChallenge> UserChallenges { get; set; }
     public virtual ICollection<ShowcaseItem> ShowcaseItems { get; set; }
     public virtual DailyStreak DailyStreak { get; set; }

--- a/TCSA.V2/Models/DTO/AppUserForReviewLeaderboard.cs
+++ b/TCSA.V2/Models/DTO/AppUserForReviewLeaderboard.cs
@@ -1,0 +1,11 @@
+﻿namespace TCSA.V2.Models.DTOs;
+    public class AppUserForReviewLeaderboard
+    {
+        public string Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string? DisplayName { get; set; }
+        public int? TotalXp { get; set; }
+        public int ReviewsNumber { get; set; }
+        public int Ranking { get; set; }
+    }

--- a/TCSA.V2/Services/LeaderboardService.cs
+++ b/TCSA.V2/Services/LeaderboardService.cs
@@ -96,7 +96,7 @@ public class LeaderboardService : ILeaderboardService
 
                         context.Users
                            .Where(x => x.Id == user.Id)
-                           .ExecuteUpdate(y => y.SetProperty(u => u.ReviewdProjects, reviewedProjects.Count));
+                           .ExecuteUpdate(y => y.SetProperty(u => u.ReviewedProjects, reviewedProjects.Count));
 
                         await context.SaveChangesAsync();
                     }
@@ -114,13 +114,16 @@ public class LeaderboardService : ILeaderboardService
                     result.Add(userForLeaderboard);
                 }
 
-                result = result.OrderByDescending(x => x.TotalXp).ToList();
+                result = result
+                    .OrderByDescending(x => x.TotalXp)
+                    .Take(50)
+                    .ToList();
+
                 foreach (var user in result)
                 {
                     user.Ranking = index;
                     index++;
                 }
-
                 return result;
             }
         }

--- a/TCSA.V2/Services/PeerReviewService.cs
+++ b/TCSA.V2/Services/PeerReviewService.cs
@@ -104,7 +104,7 @@ public class PeerReviewService : IPeerReviewService
 
                 context.Users
                     .Where(x => x.Id == reviewerId)
-                    .ExecuteUpdate(y => y.SetProperty(u => u.ReviewdProjects, reviewer.ReviewdProjects + 1));
+                    .ExecuteUpdate(y => y.SetProperty(u => u.ReviewedProjects, reviewer.ReviewedProjects + 1));
 
                 await context.SaveChangesAsync();
             }

--- a/TCSA.V2/Services/PeerReviewService.cs
+++ b/TCSA.V2/Services/PeerReviewService.cs
@@ -88,6 +88,8 @@ public class PeerReviewService : IPeerReviewService
 
                         reviewer.ReviewExperiencePoints = reviewer.ReviewExperiencePoints + reviewAcademyProject.ExperiencePoints;
                     }
+                    //If reviewer has no experience points set, that means the reviewedProjects column is also not set yet.
+                    reviewer.ReviewedProjects = reviewedProjects.Count;
                 }
 
                 context.Users


### PR DESCRIPTION
This was a very extensive change.

I teested it with a some dummy records in my local database and everything worked as expected. But i would suggest testing it with a clone of the production db used on the site.

I made sure to add retroactive checks since i wanted  the leaderboard to not make constant database querys and to make sure every user get's accounted for.

Overall what was changed:

- 2 new columns in the ApplicaitonUser table
- new DTO "AppUserForReviewLeaderboard"
- new button in the leaderboard page
- PeerReviewService and LeaderboardService classes where updated with new logic for updating the new columns and for retroactive calculation of xp for users that already have reviewed projects.

It might be needed in the future to refactor the PeerReviewClass to separate the logic in a different method.
To test this, it will be needed to run both:

- "Add-Migration"
- "Update-Database"

commands since new columns were added.

