### PR TITLE
[Feature] Single Loading Component and Peer Review Loading Actions

### DIFF
--- a/TCSA.V2/Components/Admin/Pages/Create.razor
+++ b/TCSA.V2/Components/Admin/Pages/Create.razor
@@ -68,9 +68,7 @@
 
         @if (isSubmitting)
         {
-            <div class="spinner-border" role="status">
-                <span class="visually-hidden">Loading...</span>
-            </div>
+            <LoadingSpinner />
         }
         else
         {

--- a/TCSA.V2/Components/Articles/BlogForm.razor
+++ b/TCSA.V2/Components/Articles/BlogForm.razor
@@ -1,4 +1,5 @@
-﻿@using TCSA.V2.Helpers
+﻿@using TCSA.V2.Components.UI
+@using TCSA.V2.Helpers
 @using TCSA.V2.Models
 @using TCSA.V2.Data
 @using TCSA.V2.Models.DTO
@@ -27,16 +28,14 @@
         <label for="body">Content</label>
     </div>
 
-    @if (!IsSubmitting)
+    @if (IsSubmitting)
     {
-        <button class="btn btn-success btn-academy mt-1" type="submit">Submit</button>
-        <button class="btn btn-secondary btn-academy mt-1" type="button" @onclick="() => SubmitProject(true)">Save as Draft</button>
+        <LoadingSpinner />
     }
     else
     {
-        <div class="spinner-border" role="status">
-            <span class="visually-hidden"></span>
-        </div>
+        <button class="btn btn-success btn-academy mt-1" type="submit">Submit</button>
+        <button class="btn btn-secondary btn-academy mt-1" type="button" @onclick="() => SubmitProject(true)">Save as Draft</button>
     }
 </EditForm>
 

--- a/TCSA.V2/Components/Dashboard/DashboardChallengeCard.razor
+++ b/TCSA.V2/Components/Dashboard/DashboardChallengeCard.razor
@@ -1,4 +1,5 @@
-﻿@using TCSA.V2.Components.UI.SVGs
+﻿@using TCSA.V2.Components.UI
+@using TCSA.V2.Components.UI.SVGs
 @using TCSA.V2.Data
 @using TCSA.V2.Helpers
 @using TCSA.V2.Models
@@ -55,9 +56,7 @@
                 <div class="col-12 view-btn">
                     @if (IsLoading)
                     {
-                        <div class="spinner-border" role="status">
-                            <span class="sr-only"></span>
-                        </div>
+                        <LoadingSpinner />
                     }
                     else
                     {
@@ -126,9 +125,7 @@
                 <div class="col-12 view-btn">
                     @if (IsLoading)
                     {
-                        <div class="spinner-border" role="status">
-                            <span class="sr-only"></span>
-                        </div>
+                        <LoadingSpinner />
                     }
                     else
                     {

--- a/TCSA.V2/Components/Dashboard/DashboardReviewCard.razor
+++ b/TCSA.V2/Components/Dashboard/DashboardReviewCard.razor
@@ -1,4 +1,5 @@
-﻿@using TCSA.V2.Components.UI.SVGs
+﻿@using TCSA.V2.Components.UI
+@using TCSA.V2.Components.UI.SVGs
 @using Components.Dashboard.Shared
 @using Octokit.Webhooks.Models
 
@@ -34,46 +35,51 @@
             </div>
             @if (Status != "is-assigned")
             {
-            <div class="row text-center">
-                <div class="col-12 view-btn">
-                    <a target="_blank" href="" @onclick:preventDefault @onclick=AssignTask class="tw-flex tw-flex-col tw-items-center tw-gap-1">
-                        <TakeSVG/>
-                        <div class="col-12 dashboard-review-action-text">
-                            Take
-                        </div>
-                    </a>
+                <div class="row text-center">
+                    <div class="col-12 view-btn">
+                        @if (IsLoading)
+                        {
+                            <LoadingSpinner />
+                        }
+                        else
+                        {
+                            <a target="_blank" href="" @onclick:preventDefault @onclick="OnAssign" class="tw-flex tw-flex-col tw-items-center tw-gap-1">
+                                <TakeSVG />
+                                <div class="col-12 dashboard-review-action-text">
+                                    Take
+                                </div>
+                            </a>
+                        }
+                    </div>
                 </div>
-            </div>
             }
             else
             {
-            <div class="row text-center">
-                @if (Loading)
-                {
-                <div class="col-12 dashboard-review-action-text">
-                    <Loader/>
-                </div>
-                }
-                else
-                {
-                <div class="col-6 view-btn">
-                    <a target="_blank" href="" @onclick:preventDefault @onclick="OnMarkAsCompleteCallBack" class="tw-flex tw-flex-col tw-items-center tw-gap-1">
-                        <ApproveSVG/>
-                        <div class="col-12 dashboard-review-action-text">
-                            Approve
+                <div class="row text-center">
+                    @if (IsLoading)
+                    {
+                        <LoadingSpinner />
+                    }
+                    else
+                    {
+                        <div class="col-6 view-btn">
+                            <a target="_blank" href="" @onclick:preventDefault @onclick="OnMarkAsComplete" class="tw-flex tw-flex-col tw-items-center tw-gap-1">
+                                <ApproveSVG />
+                                <div class="col-12 dashboard-review-action-text">
+                                    Approve
+                                </div>
+                            </a>
                         </div>
-                    </a>
-                </div>
-                <div class="col-6 view-btn">
-                    <a target="_blank" href="" @onclick:preventDefault @onclick="OnReleaseCallBack" class="tw-flex tw-flex-col tw-items-center tw-gap-1">
-                        <TakeSVG/>
-                        <div class="col-12 dashboard-review-action-text">
-                            Release
+                        <div class="col-6 view-btn">
+                            <a target="_blank" href="" @onclick:preventDefault @onclick="OnRelease" class="tw-flex tw-flex-col tw-items-center tw-gap-1">
+                                <TakeSVG />
+                                <div class="col-12 dashboard-review-action-text">
+                                    Release
+                                </div>
+                            </a>
                         </div>
-                    </a>
+                    }
                 </div>
-                }
-            </div>
             }
         </div>
     </div>
@@ -93,20 +99,32 @@
     [Parameter] public EventCallback OnMarkAsCompleteCallBack { get; set; }
     [Parameter] public MarkupString DurationOpen { get; set; }
     public string Href { get; set; }
-    public bool Loading { get; set; }
+    public bool IsLoading { get; set; }
 
     protected async override Task OnParametersSetAsync()
     {
         Href = $"project/{ProjectId}/{ProjectSlug}";
     }
 
-    private async Task AssignTask()
+    private async Task OnAssign()
     {
-        Loading = true;
+        IsLoading = true;
         await OnAssignCallBack.InvokeAsync();
-        int milliseconds = 2000;
-        await Task.Delay(milliseconds);
-        Loading = false;
+        IsLoading = false;
+    }
+
+    private async Task OnMarkAsComplete()
+    {
+        IsLoading = true;
+        await OnMarkAsCompleteCallBack.InvokeAsync();
+        IsLoading = false;
+    }
+
+    private async Task OnRelease()
+    {
+        IsLoading = true;
+        await OnReleaseCallBack.InvokeAsync();
+        IsLoading = false;
     }
 }
 

--- a/TCSA.V2/Components/Dashboard/Loader.razor
+++ b/TCSA.V2/Components/Dashboard/Loader.razor
@@ -1,5 +1,0 @@
-﻿<div class="spinner-border text-primary" role="status">
-	<span class="visually-hidden">Loading...</span>
-</div>
-
-

--- a/TCSA.V2/Components/Dashboard/Pages/Community.razor
+++ b/TCSA.V2/Components/Dashboard/Pages/Community.razor
@@ -4,6 +4,7 @@
 
 @using System.Security.Claims;
 @using TCSA.V2.Components.Dashboard.Shared
+@using TCSA.V2.Components.UI
 @using TCSA.V2.Components.UI.SVGs
 @using TCSA.V2.Data
 @using TCSA.V2.Helpers
@@ -15,7 +16,11 @@
 <PageTitle>@StringConstants.PageTitle - Community Projects</PageTitle>
 
 <div class="mt-md-5 pt-md-5">
-    @if (user != null)
+    @if (user == null)
+    {
+        <LoadingSpinner />
+    }
+    else
     {
         <div class="row">
             @if (createIssue)
@@ -58,9 +63,7 @@
                             </div>
                             @if (isSubmittingIssue)
                             {
-                                <div class="spinner-border text-primary" role="status">
-                                    <span class="visually-hidden">Loading...</span>
-                                </div>
+                                <LoadingSpinner />
                             } else
                             {
                                 <button class="btn btn-outline-secondary mb-3" type="submit">Submit</button>
@@ -153,10 +156,6 @@
                 }
             </div>
         </div>
-    }
-    else
-    {
-        <div class="spinner"></div>
     }
 </div>
 

--- a/TCSA.V2/Components/Dashboard/Pages/Dashboard.razor
+++ b/TCSA.V2/Components/Dashboard/Pages/Dashboard.razor
@@ -32,15 +32,13 @@
                         <div class="row">
                             <div class="col-10 d-flex align-items-center">@GetProjectName(project) was marked as complete!</div>
                             <div class="col-2">
-                                @if (!IsLoading)
+                                @if (IsLoading)
                                 {
-                                    <button class="btn btn-outline-light" type="button" @onclick="() => DismissIsCompleteNotification(project)">Dismiss</button>
+                                    <LoadingSpinner />
                                 }
                                 else
                                 {
-                                    <div class="spinner-border" role="status">
-                                        <span class="visually-hidden">Loading...</span>
-                                    </div>
+                                    <button class="btn btn-outline-light" type="button" @onclick="() => DismissIsCompleteNotification(project)">Dismiss</button>
                                 }
                             </div>
                         </div>

--- a/TCSA.V2/Components/Dashboard/Pages/PeerReviews.razor
+++ b/TCSA.V2/Components/Dashboard/Pages/PeerReviews.razor
@@ -126,14 +126,11 @@
         projectCompleted = true;
 
         availableProjects = await PeerReviewService.GetProjectsForPeerReview(userId);
-
-        User = await PeerReviewService.GetUserForPeerReview(userId);
     }
 
     private async Task AssignMyself(int id)
     {
         await PeerReviewService.AssignUserToCodeReview(userId, id);
-        User = await PeerReviewService.GetUserForPeerReview(userId);
 
         userAssigned = true;
 
@@ -143,7 +140,6 @@
     private async Task ReleaseMyself(int id)
     {
         await PeerReviewService.ReleaseUserFromCodeReview(userId, id);
-        User = await PeerReviewService.GetUserForPeerReview(userId);
 
         userReleased = true;
 
@@ -169,7 +165,6 @@
     {
         projectCompleted = false;
     }
-
 }
 
 <style>

--- a/TCSA.V2/Components/Dashboard/Pages/ProjectSubmission.razor
+++ b/TCSA.V2/Components/Dashboard/Pages/ProjectSubmission.razor
@@ -4,6 +4,7 @@
 @rendermode InteractiveServer
 
 @using System.Security.Claims;
+@using TCSA.V2.Components.UI
 @using TCSA.V2.Helpers
 @using TCSA.V2.Models
 @using TCSA.V2.Models.Forms
@@ -31,9 +32,7 @@
 
                 @if (IsSubmitting)
                 {
-                    <div class="spinner-border text-primary" role="status">
-                        <span class="visually-hidden">Loading...</span>
-                    </div>
+                    <LoadingSpinner />
                 }
                 else
                 {
@@ -94,9 +93,7 @@ else
 
             @if (IsSubmitting)
             {
-                <div class="spinner-border text-primary" role="status">
-                    <span class="visually-hidden">Loading...</span>
-                </div>
+                <LoadingSpinner />
             }
             else
             {

--- a/TCSA.V2/Components/Dashboard/Pages/Roadmap.razor
+++ b/TCSA.V2/Components/Dashboard/Pages/Roadmap.razor
@@ -3,6 +3,7 @@
 
 @using System.Security.Claims;
 @using TCSA.V2.Components.Dashboard.Shared
+@using TCSA.V2.Components.UI
 @using TCSA.V2.Data
 @using TCSA.V2.Helpers
 @using TCSA.V2.Models
@@ -13,9 +14,7 @@
 
 @if (isLoading)
 {
-    <div class="spinner-border text-primary" role="status">
-        <span class="visually-hidden">Loading...</span>
-    </div>
+    <LoadingSpinner />
 }
 else
 {

--- a/TCSA.V2/Components/Dashboard/Shared/DashboardNavMenu.razor.css
+++ b/TCSA.V2/Components/Dashboard/Shared/DashboardNavMenu.razor.css
@@ -101,6 +101,10 @@
     color: white;
 }
 
+.nav-link {
+  cursor: pointer;
+}
+
 .nav-scrollable {
     display: none;
 }

--- a/TCSA.V2/Components/Gallery/Gallery.razor
+++ b/TCSA.V2/Components/Gallery/Gallery.razor
@@ -87,9 +87,7 @@
     {
         if (IsLoading)
         {
-            <div class="spinner-border" role="status">
-                <span class="visually-hidden"></span>
-            </div>
+            <LoadingSpinner />
         } 
         else
         {

--- a/TCSA.V2/Components/Gallery/ShowcaseItemForm.razor
+++ b/TCSA.V2/Components/Gallery/ShowcaseItemForm.razor
@@ -1,4 +1,5 @@
-﻿@using TCSA.V2.Helpers
+﻿@using TCSA.V2.Components.UI
+@using TCSA.V2.Helpers
 @using TCSA.V2.Models
 @using TCSA.V2.Data
 @using TCSA.V2.Models.DTO
@@ -24,14 +25,12 @@
         <InputText id="githubUrl" class="form-control w-50" @bind-Value="Model.GithubUrl" />
         <label for="githubUrl">Github Url</label>
     </div>
-    @if (!IsSubmitting)
+    @if (IsSubmitting)
     {
-        <button class="btn btn-success btn-academy mt-1" type="submit">Submit</button>
+        <LoadingSpinner />
     } else
     {
-        <div class="spinner-border" role="status">
-            <span class="visually-hidden"></span>
-        </div>
+        <button class="btn btn-success btn-academy mt-1" type="submit">Submit</button>
     }
 
 </EditForm>

--- a/TCSA.V2/Components/Pages/ArticlePage.razor
+++ b/TCSA.V2/Components/Pages/ArticlePage.razor
@@ -131,9 +131,7 @@
                 <div class="user-buttons mt-3">
                     @if (IsLoading)
                     {
-                        <div class="spinner-border text-primary" role="status">
-                            <span class="visually-hidden">Loading...</span>
-                        </div>
+                        <LoadingSpinner />
                     }
                     else
                     {


### PR DESCRIPTION
## FEATURES

### Implemented single `LoadingSpinner` UI component and deleted the duplicate and bespoke implementations.
`~\TCSA.V2\Components\UI\LoadingSpinner.razor`.



### Adjusted logic to make the positive loading condition the first statement.

❌ 
```
if (!isLoading)
{
    // Some UI.
}
else
{
   <LoadingSpinner />
}
```

✔️ 
```
if (isLoading)
{
   <LoadingSpinner />
}
else
{
    // Some UI.
}
```



### Implemented LoadingSpinner on the peer review dashboard page for assigning, approving and releasing actions.

![image](https://github.com/user-attachments/assets/0cbef838-83b0-47b2-837e-21b8fcf2526e)

NOTE: Tested by artificially adding a network slowness/delay in the `PeerReviewService.cs` implementation - THIS CHANGE HAS NOT BEEN COMMITTED (for obvious reasons).

![image](https://github.com/user-attachments/assets/51bae194-b7a0-4d1a-b9f8-fc629ab3dda4)
![image](https://github.com/user-attachments/assets/c042d045-4318-49c7-baaa-ebff2cb94114)
![image](https://github.com/user-attachments/assets/3d284d7a-c4ba-49b4-9590-93b8897d4945)

Also, the live version currently has an artificial delay left in... oops! I have removed this.
![image](https://github.com/user-attachments/assets/f66b469f-c4b9-4817-9599-af9332b96a32)


## BONUS FEATURES
### Removed unnecessary user lookups from peer review actions.

This should save some db calls.

### Changed cursor to pointer on dashboard navlinks rather than default.

Improve UX by letting user know these are clickable links.

closes #312 

Thanks,
@chrisjamiecarter 