### PR TITLE
Changed cookies created for external auth to persist beyond the current session

### DIFF
--- a/TCSA.V2/Components/Account/Pages/ExternalLogin.razor
+++ b/TCSA.V2/Components/Account/Pages/ExternalLogin.razor
@@ -102,7 +102,7 @@
         var result = await SignInManager.ExternalLoginSignInAsync(
             externalLoginInfo.LoginProvider,
             externalLoginInfo.ProviderKey,
-            isPersistent: false,
+            isPersistent: true,
             bypassTwoFactor: true);
 
         if (result.Succeeded)
@@ -163,7 +163,7 @@
                     RedirectManager.RedirectTo("Account/RegisterConfirmation", new() { ["email"] = Input.Email });
                 }
 
-                await SignInManager.SignInAsync(user, isPersistent: false, externalLoginInfo.LoginProvider);
+                await SignInManager.SignInAsync(user, isPersistent: true, externalLoginInfo.LoginProvider);
                 RedirectManager.RedirectTo(ReturnUrl);
             }
         }


### PR DESCRIPTION
All I've done is change `isPersistent` to true in both cases where a user is signed in after initial registration using Github or when they log in using Github any other time. 

I believe this aligns with typical expected behavior of external auth. However, I realize this is something of a design and UX decision, so it's totally up to you whether you want to make the change. 

I just thought I'd go ahead and make a PR since it was a very quick and easy change.